### PR TITLE
Be usable on Node.js

### DIFF
--- a/lib/x18n.coffee
+++ b/lib/x18n.coffee
@@ -1,3 +1,5 @@
+isNode = typeof module isnt 'undefined' and module.exports
+
 base = (Observable) ->
 	class x18n
 
@@ -65,7 +67,9 @@ base = (Observable) ->
 			@defaultLocal = local
 			@sortLocales()
 
-		@detectLocal: -> navigator.userLanguage || navigator.language
+		@detectLocal: ->
+				return 'en' if isNode
+				navigator.userLanguage || navigator.language
 
 		@similiarLocales: (local) ->
 			local = String(local).slice(0, 2).toLowerCase()
@@ -114,7 +118,7 @@ base = (Observable) ->
 				eval.call(window, src)
 			)(src)
 
-		oldT = window.t
+		oldT = window.t if not isNode
 
 		@t: (key, interpolation...) =>
 			tr = undefined
@@ -144,11 +148,13 @@ base = (Observable) ->
 			window.t = oldT
 			x18n.t
 
-		window.t = @t
+		window.t = @t if not isNode
 
 		@on 'dict:change', -> x18n.sortLocales()
 
 if typeof define is 'function' and define.amd
 	define 'x18n', ['observable'], (Observable) -> base(Observable)
+else if isNode
+	module.exports = base(module.exports)
 else
 	window.x18n = base(Observable)

--- a/lib/x18n.js
+++ b/lib/x18n.js
@@ -120,9 +120,11 @@
 }).call(this);
 
 (function() {
-  var base,
+  var base, isNode,
     __slice = [].slice,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+  isNode = typeof module !== 'undefined' && module.exports;
 
   base = function(Observable) {
     var x18n;
@@ -230,6 +232,9 @@
       };
 
       x18n.detectLocal = function() {
+        if (isNode) {
+          return 'en';
+        }
         return navigator.userLanguage || navigator.language;
       };
 
@@ -289,7 +294,9 @@
         })(src);
       };
 
-      oldT = window.t;
+      if (!isNode) {
+        oldT = window.t;
+      }
 
       x18n.t = function() {
         var interpolation, key, local, tr, _i, _len, _ref;
@@ -330,7 +337,9 @@
         return x18n.t;
       };
 
-      window.t = x18n.t;
+      if (!isNode) {
+        window.t = x18n.t;
+      }
 
       x18n.on('dict:change', function() {
         return x18n.sortLocales();
@@ -345,6 +354,8 @@
     define('x18n', ['observable'], function(Observable) {
       return base(Observable);
     });
+  } else if (isNode) {
+    module.exports = base(module.exports);
   } else {
     window.x18n = base(Observable);
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"devDependencies": {
 		"grunt": "~0.3",
 		"grunt-contrib-coffee": "~0.3",
-		"grunt-mocha": "~0.1"
+		"grunt-mocha": "~0.1",
+		"mocha": "~1.12.0"
 	}
 }

--- a/spec/spec.coffee
+++ b/spec/spec.coffee
@@ -1,5 +1,15 @@
+if typeof module isnt 'undefined'
+	x18n = require('../lib/x18n.js')
+	t = x18n.t
+	expect = require('./vendor/chai.js').expect
+else
+	x18n = window.x18n
+	t = x18n.t
+	expect = window.expect
+
 utils = x18n.utils
 dict = x18n.dict
+isNode = typeof window is 'undefined'
 
 describe 'x18n', ->
 	afterEach ->
@@ -123,16 +133,18 @@ describe 'x18n', ->
 			expect(x18n.resolveBindings(str)).to.equal(str)
 			x18n.dynamicBindings = true # clean up
 
-		it 'should evaluate dynamic bindings', ->
-			expect(x18n.resolveBindings('2 + 2 = ${2 + 2}')).to.equal('2 + 2 = 4')
+		if not isNode
+			it 'should evaluate dynamic bindings', ->
+				expect(x18n.resolveBindings('2 + 2 = ${2 + 2}')).to.equal('2 + 2 = 4')
 
-			window.user = name: 'John'
-			expect(x18n.resolveBindings('Hello ${user.name}')).to.equal('Hello John')
+				window.user = name: 'John'
+				expect(x18n.resolveBindings('Hello ${user.name}')).to.equal('Hello John')
 
 	describe 't', ->
-		it 'should be defined in the global and x18n scope', ->
-			expect(window).to.have.property('t')
-			expect(x18n).to.have.property('t')
+		if not isNode
+			it 'should be defined in the global and x18n scope', ->
+				expect(window).to.have.property('t')
+				expect(x18n).to.have.property('t')
 
 		it 'should return the translation', ->
 			x18n.register 'de', user: 'benutzer'
@@ -177,12 +189,13 @@ describe 'x18n', ->
 
 			expect(t('a', s: 'World')).to.equal('Hello World')
 
-		it 'should support dynamic bindings', ->
-			window.user = name: 'John'
-			x18n.register 'en',
-				welcome: 'Welcome ${user.name}'
+		if not isNode
+			it 'should support dynamic bindings', ->
+				window.user = name: 'John'
+				x18n.register 'en',
+					welcome: 'Welcome ${user.name}'
 
-			expect(t('welcome')).to.equal('Welcome John')
+				expect(t('welcome')).to.equal('Welcome John')
 
 		it 'should return an object with a plural method when requesting a plural', ->
 			x18n.register 'en',
@@ -201,29 +214,32 @@ describe 'x18n', ->
 			expect(t('users').plural(1)).to.equal('There is 1 user online')
 			expect(t('users').plural(3)).to.equal('There are 3 users online')
 
-		it 'should support dynamic bindings for interpolation', ->
-			window.user = name: 'John'
-			x18n.register 'en',
-				welcome: 'Welcome %1'
+		if not isNode
+			it 'should support dynamic bindings for interpolation', ->
+				window.user = name: 'John'
+				x18n.register 'en',
+					welcome: 'Welcome %1'
 
-			expect(t('welcome', '${user.name}')).to.equal('Welcome John')
+				expect(t('welcome', '${user.name}')).to.equal('Welcome John')
 
-			x18n.register 'en',
-				welcome: 'Welcome %{name}'
+				x18n.register 'en',
+					welcome: 'Welcome %{name}'
 
-			expect(t('welcome', name: '${user.name}')).to.equal('Welcome John')
+				expect(t('welcome', name: '${user.name}')).to.equal('Welcome John')
 
-		it 'should support dynamic bindings for plurals', ->
-			window.users = length: 50
-			x18n.register 'en',
-				users:
-					1: 'There is 1 user online'
-					n: 'There are %1 users online'
+		if not isNode
+			it 'should support dynamic bindings for plurals', ->
+				window.users = length: 50
+				x18n.register 'en',
+					users:
+						1: 'There is 1 user online'
+						n: 'There are %1 users online'
 
-			expect(t('users').plural('${users.length}')).to.equal('There are 50 users online')
+				expect(t('users').plural('${users.length}')).to.equal('There are 50 users online')
 
-		describe 'noConflict', ->
-			it 'should restore the old t and return t', ->
-				t = window.t.noConflict()
-				expect(t).to.equal(x18n.t)
-				window.t = t
+		if not isNode
+			describe 'noConflict', ->
+				it 'should restore the old t and return t', ->
+					t = window.t.noConflict()
+					expect(t).to.equal(x18n.t)
+					window.t = t


### PR DESCRIPTION
I am also using the `x18n` for the Web application.

However, during development, I sometimes run a part of application's tests by `mocha` command.
 For that reason, I changed to be usable on Node.js.

Could you add support for Node.js?


### Test results

By `mocha` command:
```
$ npm install
$ grunt
$ ./node_modules/mocha/bin/mocha spec/spec.js

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  30 passing (29 ms)
```

And browser test is passing too:
```
$ grunt test                                 
Running "mocha:all" (mocha) task
Testing index.html....................................OK
>> 36 assertions passed (0.22s)

Done, without errors.
```